### PR TITLE
bugfix(socket): Remove duplicate closure of sockets on error

### DIFF
--- a/tproxy_tcp.go
+++ b/tproxy_tcp.go
@@ -68,9 +68,7 @@ func ListenTCP(network string, laddr *net.TCPAddr) (net.Listener, error) {
 	}
 	defer fileDescriptorSource.Close()
 
-	fileDescriptor := int(fileDescriptorSource.Fd())
-	if err = syscall.SetsockoptInt(fileDescriptor, syscall.SOL_IP, syscall.IP_TRANSPARENT, 1); err != nil {
-		syscall.Close(fileDescriptor)
+	if err = syscall.SetsockoptInt(int(fileDescriptorSource.Fd()), syscall.SOL_IP, syscall.IP_TRANSPARENT, 1); err != nil {
 		return nil, &net.OpError{Op: "listen", Net: network, Source: nil, Addr: laddr, Err: fmt.Errorf("set socket option: IP_TRANSPARENT: %s", err)}
 	}
 

--- a/tproxy_udp.go
+++ b/tproxy_udp.go
@@ -28,12 +28,10 @@ func ListenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {
 
 	fileDescriptor := int(fileDescriptorSource.Fd())
 	if err = syscall.SetsockoptInt(fileDescriptor, syscall.SOL_IP, syscall.IP_TRANSPARENT, 1); err != nil {
-		syscall.Close(fileDescriptor)
 		return nil, &net.OpError{Op: "listen", Net: network, Source: nil, Addr: laddr, Err: fmt.Errorf("set socket option: IP_TRANSPARENT: %s", err)}
 	}
 
 	if err = syscall.SetsockoptInt(fileDescriptor, syscall.SOL_IP, syscall.IP_RECVORIGDSTADDR, 1); err != nil {
-		syscall.Close(fileDescriptor)
 		return nil, &net.OpError{Op: "listen", Net: network, Source: nil, Addr: laddr, Err: fmt.Errorf("set socket option: IP_RECVORIGDSTADDR: %s", err)}
 	}
 


### PR DESCRIPTION
Remove calls to `syscall.Close()` when a error is handled when applying
a socket option, this call would duplicate the calls to close the
sockets file descriptor as a defered call to close the file is set
before applying socket options.

Will resolve issue ticket #1 